### PR TITLE
Fix handling of attached retroflex in pinyinize

### DIFF
--- a/cedict/pinyin.py
+++ b/cedict/pinyin.py
@@ -5,6 +5,10 @@ import re
 PINYIN_RE = re.compile(r'(([bcdfghjklmnpqrstwxyz]*)'
         r'([aeiouv]+)([bcdfghjklmnpqrstwxyz]*)|r)([1-5])', re.I)
 
+UNATTACHED_RETROFLEX_RE = re.compile(r' r( |$)')
+
+ATTACHED_RETROFLEX = r'r\1'
+
 
 INITIALS_TO_FINALS = {
     '': {
@@ -267,10 +271,11 @@ def pinyinize(src, raise_exception=False):
     try:
         def replacer(m):
             syllable, pre, vowels, post, tone = m.groups()
-            vowels = list(vowels)
 
             if syllable.lower() == 'r' and tone == '5':
                 return syllable
+
+            vowels = list(vowels)
 
             tone = int(tone)
 
@@ -309,7 +314,7 @@ def pinyinize(src, raise_exception=False):
                     raise
                 return m.group(0)
 
-        return PINYIN_RE.sub(replacer, src)
+        return UNATTACHED_RETROFLEX_RE.sub(ATTACHED_RETROFLEX, PINYIN_RE.sub(replacer, src))
     except:  # noqa
         # import sys
         # import traceback


### PR DESCRIPTION
The [CC-CEDICT syntax wiki](https://cc-cedict.org/wiki/format:syntax#retroflex_finals) describes the retroflex finals as:

> There are 3 kinds of R-ised words that use the 兒/儿 character:
> 
> 兒/儿 is not-optional because it's its own syllable (usually meaning “son,” so daughter is actually “girl son”) - 女兒/女儿 nǚ'ér
兒/儿 is not-optional because it changes the definition of the word and is tacked on to the preceding syllable - 头兒/头儿 tóur (leader) as opposed to 头 tóu (head)
兒/儿 is an optional northern pronunciation (er2hua4) and is tacked on to the preceding syllable - 花兒/花儿 huār (flower) as opposed to 花 huā (flower)
These 3 cases should be formatted as follows:
> 
> 女兒 女儿 [nu:3 er2] /daughter/
頭兒 头儿 [tou2 r5] /leader/
花兒 花儿 [hua1 r5] /erhua variant of 花/flower/

However, in pycedict, cases 2 and 3 are not properly handled by `pinyinize`. The problem is two fold:
1. pinyinize assumes the syllable has vowels, so with `r5` it fails at `vowels = list(vowels)`.
2. The final retroflex is not attached to the previous sillable.

This problem was raised as issue #2.

This PR aims at fixing both problems by:
1. Moving the offending `vowels = list(vowels)` after the already existing special handling of `r5`.
2. Attaching any final retroflex with a regular expression.

A diff between the results with and without the fix did not show any breaking cases.